### PR TITLE
Fix Port view minigraph description when using "Interface Description…

### DIFF
--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -42,7 +42,7 @@ if ($if_list) {
         $port = cleanPort($port);
         $done = 'yes';
         unset($class);
-        $port['ifAlias'] = str_ireplace($type . ': ', '', $port['ifAlias']);
+        $port['ifAlias'] = str_ireplace($port['type'] . ': ', '', $port['ifAlias']);
         $port['ifAlias'] = str_ireplace('[PNI]', 'Private', $port['ifAlias']);
         $ifclass = ifclass($port['ifOperStatus'], $port['ifAdminStatus']);
         if ($bg == '#ffffff') {


### PR DESCRIPTION
… Parsing"

Found the exact source of the display missing ": " between port_type and ifAlias in the Ports view (Core, Transit, Peering). Title of linked-port I fixed by using port_descr_descr in  #13143 

Port description: Core: core.router01 FastEthernet0/0 (Telco X CCID023141)
Current result in device-Ports (/device/X/ports): Core: core.router01 FastEthernet0/0 (Telco X CCID023141)
Current result in ports-Core (/iftype/type=core: Corecore.router01 FastEthernet0/0 (Telco X CCID023141)
NEW description: Core: core.router01 FastEthernet0/0
as expected

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
